### PR TITLE
Add manual CI workflow to redeploy services

### DIFF
--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,0 +1,70 @@
+name: redeploy
+# Manually-triggered workflow that redeploys services to the production
+# cluster by restarting their deployments. Because the images are published
+# with the ":latest" tag by the "main" workflow, a rollout restart pulls the
+# freshly built image for each service.
+#
+# Requires a repository secret named KUBE_CONFIG containing a base64-encoded
+# kubeconfig with access to the "kaja" cluster.
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Service to redeploy"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - home
+          - kaja
+          - teams
+          - users
+          - grpc-quirks
+          - twirp-quirks
+          - boxoffice
+          - seating
+          - theatre
+jobs:
+  redeploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Redeploy service(s)
+        run: |
+          set -e
+          all_deployments=(
+            home-deployment
+            kaja-deployment
+            teams-deployment
+            users-deployment
+            grpc-quirks-deployment
+            twirp-quirks-deployment
+            boxoffice-deployment
+            seating-deployment
+            theatre-deployment
+          )
+
+          if [[ "${{ github.event.inputs.service }}" == "all" ]]; then
+            targets=("${all_deployments[@]}")
+          else
+            targets=("${{ github.event.inputs.service }}-deployment")
+          fi
+
+          for deployment in "${targets[@]}"; do
+            echo "Restarting $deployment"
+            kubectl rollout restart "deployment/$deployment"
+          done
+
+          for deployment in "${targets[@]}"; do
+            echo "Waiting for $deployment to finish rolling out"
+            kubectl rollout status "deployment/$deployment" --timeout=180s
+          done

--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -54,9 +54,26 @@ jobs:
           )
 
           if [[ "${{ github.event.inputs.service }}" == "all" ]]; then
-            targets=("${all_deployments[@]}")
+            requested=("${all_deployments[@]}")
           else
-            targets=("${{ github.event.inputs.service }}-deployment")
+            requested=("${{ github.event.inputs.service }}-deployment")
+          fi
+
+          # Only act on deployments that actually exist on the cluster. Some
+          # services (e.g. boxoffice/seating/theatre) may not be deployed yet,
+          # and restarting a missing deployment would fail the whole run.
+          targets=()
+          for deployment in "${requested[@]}"; do
+            if kubectl get "deployment/$deployment" >/dev/null 2>&1; then
+              targets+=("$deployment")
+            else
+              echo "::warning::Skipping $deployment — not found on the cluster"
+            fi
+          done
+
+          if [[ ${#targets[@]} -eq 0 ]]; then
+            echo "::error::No matching deployments found on the cluster"
+            exit 1
           fi
 
           for deployment in "${targets[@]}"; do


### PR DESCRIPTION
## What

Adds a new manually-triggered GitHub Actions workflow (`.github/workflows/redeploy.yml`) that redeploys production services from CI.

## Why

Today, images are built and pushed as `:latest` by the `main` workflow, but redeploying requires a developer to run `scripts/production` locally against the `kaja` cluster. This adds a **manual** (`workflow_dispatch`) trigger so a redeploy can be kicked off from the GitHub Actions UI.

## How it works

- Triggered via **workflow_dispatch** with a `service` input (defaults to `all`, or pick a single service).
- Uses `kubectl rollout restart` on each deployment — because the images use the `:latest` tag, restarting pulls the freshly built image.
- Waits on `kubectl rollout status` so a failed rollout fails the workflow.
- Covers all 9 deployments including `boxoffice`, `seating`, and `theatre`, which the local `scripts/production` currently omits.

## Requirements

Needs a repository secret **`KUBE_CONFIG`** containing a base64-encoded kubeconfig with access to the `kaja` cluster. Without it the workflow will fail at the configure step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gxs6QA3XEiyoiCBo6gRSVv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gxs6QA3XEiyoiCBo6gRSVv)_