### PR TITLE
Use Recreate strategy for single-replica deployments

### DIFF
--- a/k8s/base/boxoffice.yaml
+++ b/k8s/base/boxoffice.yaml
@@ -6,6 +6,10 @@ metadata:
     app: boxoffice
 spec:
   replicas: 1
+  strategy:
+    # Single node at its pod cap: a surge pod can't be scheduled, so replace
+    # the old pod before starting the new one on redeploy.
+    type: Recreate
   selector:
     matchLabels:
       app: boxoffice

--- a/k8s/base/grpc-quirks.yaml
+++ b/k8s/base/grpc-quirks.yaml
@@ -6,6 +6,10 @@ metadata:
     app: grpc-quirks
 spec:
   replicas: 1
+  strategy:
+    # Single node at its pod cap: a surge pod can't be scheduled, so replace
+    # the old pod before starting the new one on redeploy.
+    type: Recreate
   selector:
     matchLabels:
       app: grpc-quirks

--- a/k8s/base/home.yaml
+++ b/k8s/base/home.yaml
@@ -6,6 +6,10 @@ metadata:
     app: home
 spec:
   replicas: 1
+  strategy:
+    # Single node at its pod cap: a surge pod can't be scheduled, so replace
+    # the old pod before starting the new one on redeploy.
+    type: Recreate
   selector:
     matchLabels:
       app: home

--- a/k8s/base/kaja.yaml
+++ b/k8s/base/kaja.yaml
@@ -6,6 +6,10 @@ metadata:
     app: kaja
 spec:
   replicas: 1
+  strategy:
+    # Single node at its pod cap: a surge pod can't be scheduled, so replace
+    # the old pod before starting the new one on redeploy.
+    type: Recreate
   selector:
     matchLabels:
       app: kaja

--- a/k8s/base/seating.yaml
+++ b/k8s/base/seating.yaml
@@ -6,6 +6,10 @@ metadata:
     app: seating
 spec:
   replicas: 1
+  strategy:
+    # Single node at its pod cap: a surge pod can't be scheduled, so replace
+    # the old pod before starting the new one on redeploy.
+    type: Recreate
   selector:
     matchLabels:
       app: seating

--- a/k8s/base/theatre.yaml
+++ b/k8s/base/theatre.yaml
@@ -6,6 +6,10 @@ metadata:
     app: theatre
 spec:
   replicas: 1
+  strategy:
+    # Single node at its pod cap: a surge pod can't be scheduled, so replace
+    # the old pod before starting the new one on redeploy.
+    type: Recreate
   selector:
     matchLabels:
       app: theatre

--- a/k8s/base/twirp-quirks.yaml
+++ b/k8s/base/twirp-quirks.yaml
@@ -6,6 +6,10 @@ metadata:
     app: twirp-quirks
 spec:
   replicas: 1
+  strategy:
+    # Single node at its pod cap: a surge pod can't be scheduled, so replace
+    # the old pod before starting the new one on redeploy.
+    type: Recreate
   selector:
     matchLabels:
       app: twirp-quirks


### PR DESCRIPTION
## Why

The manual **redeploy** workflow (#40) restarts deployments with \`kubectl rollout restart\`, but the run failed at the rollout-wait step for \`home\` and \`kaja\`:

\`\`\`
Waiting for deployment "home-deployment" rollout to finish: 1 old replicas are pending termination...
error: timed out waiting for the condition
\`\`\`

**Root cause (not a workflow bug):** the AKS cluster is a **single node with a 30-pod cap**, and it's currently full (30/30 Running). The default \`RollingUpdate\` strategy uses \`maxSurge: 25%\`, so a rollout tries to create the new pod *before* terminating the old one — but there's no free pod slot, so the new pod stays \`Pending\`, the old pod never terminates, and the rollout times out. Manual deploys have been silently hitting this too (some "Running" pods were hours/days older than their last restart).

\`teams\` and \`users\` already avoid this with \`strategy: type: Recreate\` (originally for Pebble's single-writer constraint).

## What

Add \`strategy: type: Recreate\` to the remaining single-replica deployments (\`home\`, \`kaja\`, \`grpc-quirks\`, \`twirp-quirks\`, \`boxoffice\`, \`seating\`, \`theatre\`). Recreate terminates the old pod first, then starts the new one — which fits within the pod cap. Trade-off is a few seconds of downtime per service during a deploy, acceptable for these demo services.

## Applying

This changes the deployment spec, so it takes effect via \`kubectl apply -k k8s/overlays/production\` (what \`scripts/production\` runs) — **not** via the redeploy workflow, which only restarts. Note that applying the full production overlay would also create the \`boxoffice\`/\`seating\`/\`theatre\` deployments for the first time, which won't schedule at the current pod cap (see PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)