### PR TITLE
Switch /demo to box office trio, drop teams/users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # Agent Guidelines
 
+## Pull Requests
+
+Keep PR descriptions short. Aim for a one-line summary plus a brief bullet list
+of the concrete changes. Skip lengthy background, root-cause narratives, and
+generated-by boilerplate — link to related PRs/issues instead of restating them.
+
 ## Proto Files
 
 To regenerate proto files after modifying `.proto` definitions, run:

--- a/apps/kaja/kaja.json
+++ b/apps/kaja/kaja.json
@@ -2,18 +2,6 @@
   "pathPrefix": "/demo",
   "projects": [
     {
-      "name": "teams",
-      "protocol": "RPC_PROTOCOL_GRPC",
-      "url": "dns:kaja.tools:443",
-      "protoDir": "teams"
-    },
-    {
-      "name": "users",
-      "protocol": "RPC_PROTOCOL_TWIRP",
-      "url": "https://kaja.tools/users",
-      "protoDir": "users"
-    },
-    {
       "name": "theatre",
       "protocol": "RPC_PROTOCOL_OPENAPI",
       "url": "https://kaja.tools/theatre/openapi.yaml"

--- a/scripts/production
+++ b/scripts/production
@@ -13,11 +13,13 @@ POD_NAME=$(kubectl get pods -l app=kaja --field-selector=status.phase=Running -o
 echo "Copying configuration and proto files to $POD_NAME"
 kubectl exec $POD_NAME -- rm -rf /workspace/teams
 kubectl exec $POD_NAME -- rm -rf /workspace/users
-kubectl exec $POD_NAME -- mkdir /workspace/teams
-kubectl exec $POD_NAME -- mkdir /workspace/users
+kubectl exec $POD_NAME -- rm -rf /workspace/seating
+kubectl exec $POD_NAME -- rm -rf /workspace/boxoffice
+kubectl exec $POD_NAME -- mkdir /workspace/seating
+kubectl exec $POD_NAME -- mkdir /workspace/boxoffice
 kubectl cp apps/kaja/kaja.json $POD_NAME:/workspace/kaja.json
-kubectl cp apps/teams/proto/teams.proto $POD_NAME:/workspace/teams/teams.proto
-kubectl cp apps/users/proto/users.proto $POD_NAME:/workspace/users/users.proto
+kubectl cp apps/seating/proto/seating.proto $POD_NAME:/workspace/seating/seating.proto
+kubectl cp apps/boxoffice/proto/boxoffice.proto $POD_NAME:/workspace/boxoffice/boxoffice.proto
 
 kubectl delete secret secrets
 kubectl create secret generic secrets --from-literal=AI_API_KEY=$(cat .ai_api_key)
@@ -25,7 +27,8 @@ kubectl create secret generic secrets --from-literal=AI_API_KEY=$(cat .ai_api_ke
 kubectl apply -k k8s/overlays/production
 kubectl rollout restart deployment home-deployment
 kubectl rollout restart deployment kaja-deployment
-kubectl rollout restart deployment teams-deployment
-kubectl rollout restart deployment users-deployment
+kubectl rollout restart deployment theatre-deployment
+kubectl rollout restart deployment seating-deployment
+kubectl rollout restart deployment boxoffice-deployment
 kubectl rollout restart deployment grpc-quirks-deployment
 kubectl rollout restart deployment twirp-quirks-deployment


### PR DESCRIPTION
Aligns `/demo` with [wham/kaja#333](https://github.com/wham/kaja/pull/333): drops `teams`/`users`, keeps `theatre`/`seating`/`boxoffice`.

- `kaja.json`: remove `teams` and `users` projects.
- `scripts/production`: seed `seating`/`boxoffice` protos and restart those deployments instead of `teams`/`users`.

Redeploy alone doesn't update the demo (it only restarts pods). Run `./scripts/production` to seed the workspace PVC.