### PR TITLE
Modernized the /demo config to the typed apps format

### DIFF
--- a/apps/kaja/kaja.json
+++ b/apps/kaja/kaja.json
@@ -1,22 +1,25 @@
 {
   "pathPrefix": "/demo",
-  "projects": [
+  "apps": [
     {
       "name": "theatre",
-      "protocol": "RPC_PROTOCOL_OPENAPI",
-      "url": "https://kaja.tools/theatre/openapi.yaml"
+      "openapi": {
+        "spec_url": "https://kaja.tools/theatre/openapi.yaml"
+      }
     },
     {
       "name": "seating",
-      "protocol": "RPC_PROTOCOL_GRPC",
-      "url": "dns:kaja.tools:443",
-      "protoDir": "seating"
+      "grpc": {
+        "url": "dns:kaja.tools:443",
+        "proto_dir": "seating"
+      }
     },
     {
       "name": "boxoffice",
-      "protocol": "RPC_PROTOCOL_TWIRP",
-      "url": "https://kaja.tools/boxoffice",
-      "protoDir": "boxoffice"
+      "twirp": {
+        "url": "https://kaja.tools/boxoffice",
+        "proto_dir": "boxoffice"
+      }
     }
   ]
 }


### PR DESCRIPTION
The seeded `/demo` config used the legacy `projects` shape, whose OpenAPI entry didn't load as an OpenAPI app — so the theatre service showed no methods in the sidebar. Switch to the typed `apps` format so theatre loads as an OpenAPI app.